### PR TITLE
installation: also install bison and flex.

### DIFF
--- a/source/installation.rst
+++ b/source/installation.rst
@@ -115,7 +115,7 @@ kernel. This section describes the procedure of patching a kernel to support
 
 First, install the necessary dependencies::
 
-    apt-get install build-essential bc curl ca-certificates fakeroot gnupg2 libssl-dev lsb-release libelf-dev
+    apt-get install build-essential bc curl ca-certificates fakeroot gnupg2 libssl-dev lsb-release libelf-dev bison flex
 
 Then, you have to decide which kernel version to use. To find the one you are
 using currently, use ``uname -r``. Real-time patches are only available for


### PR DESCRIPTION
As per subject.

`make oldconfig` requires them, at least on Xenial `amd64` I could not run `make oldconfig` without installing those two packages in addition to what was already installed.
