### PR TITLE
Fix parameter name  in FrankaHWSim documentation

### DIFF
--- a/source/franka_ros.rst
+++ b/source/franka_ros.rst
@@ -766,7 +766,7 @@ that :ref:`franka_control <franka_control>` supports:
 |   |                                           | was specified or defines a rotation around Z by :math:`45\:°`|
 |   |                                           | and an offset by :math:`10.34\:cm` (same as Desk for the     |
 |   |                                           | hand). You can always overwrite this value by setting the ROS|
-|   |                                           | parameter ``/<arm_id>/NE_T_EE`` manually.                    |
+|   |                                           | parameter ``/<arm_id>/F_T_NE`` manually.                     |
 +---+-------------------------------------------+--------------------------------------------------------------+
 | ✔ | ``set_K_frame`` /                         | Sets the :math:`{}^{\mathrm{EE}}\mathbf{T}_{\mathrm{K}}` i.e.|
 |   | `SetKFrame`_                              | the homogenous transformation from end-effector to stiffness |


### PR DESCRIPTION
As per the code [here](https://github.com/frankaemika/franka_ros/blob/1922fc9d24e37b2a8226c522e736eaa9a65d66ca/franka_gazebo/src/franka_hw_sim.cpp#L393) the `FrankaHWSim` plugin will search for the parameter `<arm_id>/F_T_NE` instead of `<arm_id>/NE_T_EE` in order to determine the trasnformation from the flange to the nominal end effector.